### PR TITLE
apply anyuid and hostaccess scc policies to default service account

### DIFF
--- a/bin/demo-run.sh
+++ b/bin/demo-run.sh
@@ -1,18 +1,28 @@
 #!/bin/bash
 
 MINISHIFT_DIRECTORY="$(cd "$(dirname "$0")" && pwd)"
-PROJECT=minishift-demo
-APP_NAME=hello-server
+PROJECT=${PROJECT:=minishift-demo}
+APP_NAME=${APP_NAME:=hello-server}
 
 echo "Creating demo application..."
 
 echo "=========================="
-echo "(1/4) Creating new project..."
+echo "(1/4) Applying extra permissions..."
+
+# This adds anyuid and hostaccess security context constraints to default service account
+# This is acceptable for a dev environment only
+oc login -u system:admin > /dev/null
+oc adm policy add-scc-to-user anyuid system:serviceaccount:$PROJECT:default
+oc adm policy add-scc-to-user hostaccess system:serviceaccount:$PROJECT:default
+oc login -u developer > /dev/null
+
+echo "=========================="
+echo "(2/4) Creating new project..."
 
 oc new-project $PROJECT --display-name="Demo Project" --description="A demo project designed to help you start developing with Minishift" > /dev/null
 
 echo "=========================="
-echo "(2/3) Deploying hello-server..."
+echo "(3/4) Deploying hello-server..."
 
 oc process -f "$MINISHIFT_DIRECTORY"/../demo/manifests/openshift/nodejs.yaml \
   -p NAMESPACE=$PROJECT \
@@ -22,5 +32,5 @@ oc process -f "$MINISHIFT_DIRECTORY"/../demo/manifests/openshift/nodejs.yaml \
   -p LOG_LEVEL=debug \
   -p APP_VOLUME="${MINISHIFT_DIRECTORY}"/../demo/hello | oc create -f -
 
-echo "(3/3) Building hello-server Image"
+echo "(4/4) Building hello-server Image"
 oc start-build $APP_NAME --from-dir $MINISHIFT_DIRECTORY/../demo/hello


### PR DESCRIPTION
This PR removes the manual step of editing the restricted SCC object.
 
It also allows us to pass in `PROJECT` and `APP_NAME` as arguments into the `demo-run` script if desired.