### PR TITLE
[fix] template issue with openshift v 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ All of the objects created in the project will be named or prefixed with hello-s
 ```
 replication controller "hello-server-X" successfully rolled out
 ```
-You should be able to open the route listed [here](https://192.168.64.2:8443/console/project/minishift-demo/browse/routes).  A succesful deployment will respond on the URL with 
+You should be able to open the route listed [here](http://hello-server-minishift-demo.192.168.64.3.nip.io/).  A succesful deployment will respond on the URL with 
 ```
 {msg: "Hello World"}
 ```

--- a/openshift/minishift-demo.yaml
+++ b/openshift/minishift-demo.yaml
@@ -54,7 +54,8 @@ parameters:
   value: 'debug'
 
 objects:
-- kind: BuildConfig
+- apiVersion: v1
+  kind: BuildConfig
   metadata:
     annotations:
       description: Defines how to build the application
@@ -74,10 +75,12 @@ objects:
     - type: ConfigChange
 
 - kind: ImageStream
+  apiVersion: v1
   metadata:
     name: "${NAME}"
 
 - kind: Service
+  apiVersion: v1
   metadata:
     annotations:
       description: Exposes and load balances the application pods
@@ -91,6 +94,7 @@ objects:
       name: "${NAME}"
 
 - kind: Route
+  apiVersion: v1
   metadata:
     name: "${NAME}"
   spec:
@@ -100,6 +104,7 @@ objects:
       name: "${NAME}"
 
 - kind: DeploymentConfig
+  apiVersion: v1
   metadata:
     name: "${NAME}"
   selector:


### PR DESCRIPTION
issue with template when updating openshift to 3.9.  the template needed apiVersion to be set for all objects.

updated README with correct URL for accessing the running pod


fixes: #19 